### PR TITLE
Typechecking With PropTypes

### DIFF
--- a/src/background-size-control/index.js
+++ b/src/background-size-control/index.js
@@ -69,7 +69,9 @@ const UNITCONTROL_MAX = 100;
  * There are four different syntaxes you can choose from with this control: the keyword syntax ("auto", "cover", "contain" and "custom").
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.0
  * @param  	   {Object}      props                           	The props that were defined by the caller of this component.
  * @param      {string}      props.id                        	The id of the element to which labels and help text are being generated.
  * @param      {string}      props.label                     	Label shown before the spinner.

--- a/src/conditional-wrap/index.js
+++ b/src/conditional-wrap/index.js
@@ -17,7 +17,9 @@ import { cloneElement } from '@wordpress/element';
  * React component for wrapping children based on a condition.
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.0
  * @param  	   {Object}      props             		    The props that were defined by the caller of this component.
  * @param  	   {boolean}     props.condition            Whether the component should be wrapped.
  * @param  	   {JSX.Element} props.children             Any React element or elements can be passed as children. They will be rendered within the wrapper.

--- a/src/generate-svg-paths/index.js
+++ b/src/generate-svg-paths/index.js
@@ -32,7 +32,9 @@ import { Path } from '@wordpress/primitives';
  * Generates corresponding HTML `Path` elements and enables the shape to be drawn.
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.0
  * @param  	   {Object}    	 props                    	The props that were defined by the caller of this component.
  * @param  	   {Array}     	 props.paths              	List of SVG path strings.
  * @param  	   {Object}    	 props.attributes         	Object of HTML attributes used inside the opening tag to control the element’s behaviour.

--- a/src/inner-html/index.js
+++ b/src/inner-html/index.js
@@ -27,7 +27,9 @@ import { createElement } from '@wordpress/element';
  * aside from `children` are passed.
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.0
  * @param  	   {Object}      props             		 The props that will be passed through to the wrapper element.
  * @param  	   {string}      props.tagName           The tag name of the wrapper element.
  * @param  	   {string}      props.children          Children should be a string of HTML.

--- a/src/loading/index.js
+++ b/src/loading/index.js
@@ -25,7 +25,9 @@ import { Flex, FlexBlock, FlexItem, Spinner } from '@wordpress/components';
  * Spinners notify users that their action is being processed.
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.0
  * @param  	   {Object}    props                  The props that were defined by the caller of this component.
  * @param      {string}    props.label            Label shown before the spinner.
  * @param      {string}    props.className        The class that will be added with “components-loading” to the classes of the wrapper div.

--- a/src/multi-select/index.js
+++ b/src/multi-select/index.js
@@ -84,16 +84,18 @@ import defaultMessages from './messages';
  * only. That is, `selectedOptions` is an array of values only, not an array of { label, value } pairs.
  *
  * @function
- * @since		1.2.0
- * @param		{Object}		props                       The props that were defined by the caller of this component.
- * @param		{Array}			props.options 				Set of { label, value } pairs that can be selected.
- * @param		{Array}			props.selectedOptions		List of values of the options that are currently selected.
- * @param		{Function}		props.onChange 				Callback function to be triggered when the selected options change.
- * @param		{string}		props.ariaLabel				Aria-label value.
- * @param		{string} 		props.ariaDescription		Aria-description value.
- * @param		{boolean} 		props.withSearchField 		Enable search field to filter options from the list.
- * @param		{Object} 		props.messages 				Labels and notices for subcomponents. Is merged with a default value.
- * @return		{JSX.Element} 								MultiSelect component.
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since	   1.1.0
+ * @param	   {Object}			props                       The props that were defined by the caller of this component.
+ * @param	   {Array}			props.options 				Set of { label, value } pairs that can be selected.
+ * @param	   {Array}			props.selectedOptions		List of values of the options that are currently selected.
+ * @param	   {Function}		props.onChange 				Callback function to be triggered when the selected options change.
+ * @param	   {string}			props.ariaLabel				Aria-label value.
+ * @param	   {string} 		props.ariaDescription		Aria-description value.
+ * @param	   {boolean} 		props.withSearchField 		Enable search field to filter options from the list.
+ * @param	   {Object} 		props.messages 				Labels and notices for subcomponents. Is merged with a default value.
+ * @return	   {JSX.Element} 								MultiSelect component.
  * @example
  *
  * <MultiSelect

--- a/src/print-html/index.js
+++ b/src/print-html/index.js
@@ -46,7 +46,9 @@ import InnerHTML from '../inner-html';
  * and converts all numeric HTML entities to their named counterparts.
  *
  * @function
- * @since 	   1.2.0
+ * @since	   1.2.0
+ * 			   Introduced type checking.
+ * @since 	   1.0.2
  * @param  	   {Object}       props             		The props that were defined by the caller of this component.
  * @param  	   {Object}       props.content             The content object.
  * @param  	   {Array|string} props.path              	Path of the property or node element to retrieve.

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -51,7 +51,9 @@ import { formattedContent } from '@sixach/wp-block-utils';
  * be displayed as tags rather than standalone.
  *
  * @function
- * @since		1.2.0
+ * @since	   	1.2.0
+ * 			   	Introduced type checking.
+ * @since		1.1.0
  * @param		{Object}		props 						The props that were defined by the caller of this component.
  * @param		{string}		props.label 				Label shown in the element.
  * @param		{string}		props.className 			The class that will be added to the classes of the wrapper span.


### PR DESCRIPTION
This PR introduces type checking for the properties passed to each component to help us catch possible invalid data types being passed in when an instance of the component is called.

When an invalid value is provided for a prop, a warning will be thrown to the (browser) JavaScript console. PropTypes will only be checked during the run-time (development mode).