### PR TITLE
Remove use-debounce package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-block-components",
-	"version": "1.1.0-beta.1",
+	"version": "1.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -16773,11 +16773,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
-		},
-		"use-debounce": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-6.0.1.tgz",
-			"integrity": "sha512-kpvIxpa0vOLz/2I2sfNJ72mUeaT2CMNCu5BT1f2HkV9qZK27UVSOFf1sSSu+wjJE4TcR2VTXS2SM569+m3TN7Q=="
 		},
 		"util": {
 			"version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-block-components",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A collection of most used React components crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",
@@ -63,8 +63,7 @@
 		"array-move": "^3.0.1",
 		"html-react-parser": "^1.2.6",
 		"prop-types": "^15.7.2",
-		"react-easy-sort": "^1.0.2",
-		"use-debounce": "^6.0.1"
+		"react-easy-sort": "^1.0.2"
 	},
 	"devDependencies": {
 		"@babel/cli": "7.14.5",


### PR DESCRIPTION
This PR removes the previously introduce `useDebouncedCallback` hook from the [use-debounce](https://www.npmjs.com/package/use-debounce) package in favor of this hook being available as part of the [@wordpress/compose](https://github.com/WordPress/gutenberg/blob/trunk/packages/compose/src/hooks/use-debounce/index.js) package.