### PR TITLE
Default props for components without story

### DIFF
--- a/src/conditional-wrap/index.js
+++ b/src/conditional-wrap/index.js
@@ -1,15 +1,12 @@
 /**
  * Runtime type checking for React props and similar objects.
- *
- * @ignore
  */
 import PropTypes from 'prop-types';
 
 /**
  * WordPress specific abstraction layer atop React.
  *
- * @ignore
- * @see 	https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
+ * @see    https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
  */
 import { cloneElement } from '@wordpress/element';
 
@@ -17,14 +14,17 @@ import { cloneElement } from '@wordpress/element';
  * React component for wrapping children based on a condition.
  *
  * @function
+ * @since	   1.3.0
+ * 			   Added default props.
+ *  		   Indented 4 spacing.
  * @since	   1.2.0
  * 			   Introduced type checking.
  * @since 	   1.0.0
- * @param  	   {Object}      props             		    The props that were defined by the caller of this component.
- * @param  	   {boolean}     props.condition            Whether the component should be wrapped.
- * @param  	   {JSX.Element} props.children             Any React element or elements can be passed as children. They will be rendered within the wrapper.
- * @param  	   {Function}    props.wrap           	    Callback function to clone and return a new React element using element as the starting point.
- * @return 	   {JSX.Element}                   		 	A new React component wrapped with a new element.
+ * @param  	   {Object}      	props              The props that were defined by the caller of this component.
+ * @param  	   {boolean}     	props.condition    Whether the component should be wrapped.
+ * @param  	   {JSX.Element}    props.children     Any React element or elements can be passed as children. They will be rendered within the wrapper.
+ * @param  	   {Function}    	props.wrap         Callback function to clone and return a new React element using element as the starting point.
+ * @return 	   {JSX.Element}                   	   A new React component wrapped with a new element.
  * @example
  *
  * <ConditionalWrap
@@ -46,6 +46,12 @@ ConditionalWrap.propTypes = {
 	condition: PropTypes.bool,
 	children: PropTypes.element,
 	wrap: PropTypes.func,
+};
+
+ConditionalWrap.defaultProps = {
+	condition: false,
+	children: undefined,
+	wrap: undefined,
 };
 
 export default ConditionalWrap;

--- a/src/inner-html/index.js
+++ b/src/inner-html/index.js
@@ -1,22 +1,17 @@
 /**
  * Utility for libraries from the `Lodash`.
- *
- * @ignore
  */
 import { omit } from 'lodash';
 
 /**
  * Runtime type checking for React props and similar objects.
- *
- * @ignore
  */
 import PropTypes from 'prop-types';
 
 /**
  * WordPress specific abstraction layer atop React.
  *
- * @ignore
- * @see 	https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
+ * @see    https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
  */
 import { createElement } from '@wordpress/element';
 
@@ -27,19 +22,22 @@ import { createElement } from '@wordpress/element';
  * aside from `children` are passed.
  *
  * @function
+ * @since	   1.3.0
+ * 			   Added default props.
+ *  		   Indented 4 spacing.
  * @since	   1.2.0
  * 			   Introduced type checking.
  * @since 	   1.0.0
- * @param  	   {Object}      props             		 The props that will be passed through to the wrapper element.
- * @param  	   {string}      props.tagName           The tag name of the wrapper element.
- * @param  	   {string}      props.children          Children should be a string of HTML.
- * @return 	   {JSX.Element}                   		 Dangerously-rendering component.
+ * @param  	   {Object}      	props             The props that will be passed through to the wrapper element.
+ * @param  	   {string}      	props.tagName     The tag name of the wrapper element.
+ * @param  	   {string}      	props.children    Children should be a string of HTML.
+ * @return 	   {JSX.Element}                      Dangerously-rendering component.
  * @example
  *
  * const content = '<span class=\"amount\"><bdi><span class=\"currency-symbol\">&pound;<\/span>11.05<\/bdi><\/span>';
  * <InnerHTML tagName="span">{ content }</InnerHTML>
  */
-function InnerHTML( { tagName = 'div', children, ...props } ) {
+function InnerHTML( { tagName, children, ...props } ) {
 	// The DIV wrapper will be stripped by serializer, unless there are
 	// non-children props present.
 	return createElement( tagName, {
@@ -49,8 +47,19 @@ function InnerHTML( { tagName = 'div', children, ...props } ) {
 }
 
 InnerHTML.propTypes = {
+	/**
+	 * The tag name of the wrapper element.
+	 */
 	tagName: PropTypes.string,
+	/**
+	 * Children should be a string of HTML.
+	 */
 	children: PropTypes.node,
+};
+
+InnerHTML.defaultProps = {
+	tagName: 'div',
+	children: undefined,
 };
 
 export default InnerHTML;

--- a/src/print-html/index.js
+++ b/src/print-html/index.js
@@ -1,43 +1,32 @@
 /**
  * Utility for libraries from the `Lodash`.
- *
- * @ignore
  */
 import { get, isUndefined } from 'lodash';
 
 /**
  * Runtime type checking for React props and similar objects.
- *
- * @ignore
  */
 import PropTypes from 'prop-types';
 
 /**
  * HTML to React parser.
  *
- * @ignore
- * @see 	https://www.npmjs.com/package/html-react-parser
+ * @see    https://www.npmjs.com/package/html-react-parser
  */
 import parse from 'html-react-parser';
 
 /**
  * Utility helper methods specific for Sixa projects.
- *
- * @ignore
  */
 import { formattedContent } from '@sixach/wp-block-utils';
 
 /**
  * React component for wrapping children based on a condition.
- *
- * @ignore
  */
 import ConditionalWrap from '../conditional-wrap';
 
 /**
  * Component used as equivalent of Fragment with unescaped HTML.
- *
- * @ignore
  */
 import InnerHTML from '../inner-html';
 
@@ -46,15 +35,18 @@ import InnerHTML from '../inner-html';
  * and converts all numeric HTML entities to their named counterparts.
  *
  * @function
+ * @since	   1.3.0
+ * 			   Added default props.
+ *  		   Indented 4 spacing.
  * @since	   1.2.0
  * 			   Introduced type checking.
  * @since 	   1.0.2
- * @param  	   {Object}       props             		The props that were defined by the caller of this component.
- * @param  	   {Object}       props.content             The content object.
- * @param  	   {Array|string} props.path              	Path of the property or node element to retrieve.
- * @param  	   {string}       props.tagName           	Tag name of the wrapper element.
- * @param  	   {Object}       props.tagProps          	Props that will be passed through to the wrapper element.
- * @return 	   {JSX.Element}                   		 	Generated HTML output of the elements.
+ * @param  	   {Object}       	 props             The props that were defined by the caller of this component.
+ * @param  	   {Object}       	 props.content     The content object.
+ * @param  	   {Array|string}    props.path        Path of the property or node element to retrieve.
+ * @param  	   {string}       	 props.tagName     Tag name of the wrapper element.
+ * @param  	   {Object}       	 props.tagProps    Props that will be passed through to the wrapper element.
+ * @return 	   {JSX.Element}                   	   Generated HTML output of the elements.
  * @example
  *
  * <PrintHTML content={ product } path="price_html" tagName="span" tagProps={ { className: 'price' } } />
@@ -78,10 +70,29 @@ function PrintHTML( { content, path, tagName, tagProps } ) {
 }
 
 PrintHTML.propTypes = {
+	/**
+	 * The content object.
+	 */
 	content: PropTypes.object.isRequired,
+	/**
+	 * Path of the property or node element to retrieve.
+	 */
 	path: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ),
+	/**
+	 * Tag name of the wrapper element.
+	 */
 	tagName: PropTypes.string,
+	/**
+	 * Props that will be passed through to the wrapper element.
+	 */
 	Object: PropTypes.object,
+};
+
+PrintHTML.defaultProps = {
+	content: {},
+	path: null,
+	tagName: undefined,
+	tagProps: {},
 };
 
 export default PrintHTML;


### PR DESCRIPTION
This PR introduces default values for properties of components that are not going to have a storybook demo by assigning to the special `defaultProps` property.

1. ConditionalWrap
2. InnerHTML
3. PrintHTML