### PR TITLE
Babel: Minified an No Comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixach/wp-block-components",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixach/wp-block-components",
-			"version": "1.4.0",
+			"version": "1.4.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@emotion/styled": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-block-components",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "A collection of most used React components crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",


### PR DESCRIPTION
Added `--minified` and `--no-comments` to the babel CLI command. This produces a total build directory with size `156K` compared to a size of `188K` without these two options, i.e. 20% savings.

Bumped the version to `1.4.1` and published the changes in [`1.4.1-beta.0`](https://github.com/sixach/wp-block-components/packages/797902?version=1.4.1-beta.0) for testing.