### PR TITLE
Regenerate lock file with `NPM 7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13567,9 +13567,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-			"integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
+			"integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -13578,9 +13578,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-			"integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+			"integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
 			"dependencies": {
 				"browserslist": "^4.16.7",
 				"semver": "7.0.0"
@@ -13599,9 +13599,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.1.tgz",
-			"integrity": "sha512-TyofCdMzx0KMhi84mVRS8rL1XsRk2SPUNz2azmth53iRN0/08Uim9fdhQTaZTG1LqaXHYVci4RDHka6WrXfnvg==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+			"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -15064,9 +15064,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.806",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+			"version": "1.3.808",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.808.tgz",
+			"integrity": "sha512-espnsbWTuUw0a2jMwfabCc09py2ujB+FZZE1hZWn5yYijEmxzEhdhTLKUfZGjynHvdIMQ4X/Pr/t8s4eiyH/QQ=="
 		},
 		"node_modules/element-resize-detector": {
 			"version": "1.2.3",
@@ -29523,9 +29523,9 @@
 			}
 		},
 		"node_modules/react-devtools-core": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.15.0.tgz",
-			"integrity": "sha512-Y1NwrWSKRg4TtwcES2upzXFDmccAW9jrGQG2D8EGQrZhK+0hmuhgFnSdKpFc3z04CSeDT5t83RMXcmX5TkR1dA==",
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.16.0.tgz",
+			"integrity": "sha512-fqyVbp+wVVey6O4uVBk5s3J/vTiPludp7lulr6a8asTBm7DIA0vLBbjmAOLCnOlkWcgdy4mjsqOgNCbu8uICWw==",
 			"peer": true,
 			"dependencies": {
 				"shell-quote": "^1.6.1",
@@ -31954,9 +31954,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.37.5",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-			"integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+			"integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0"
@@ -47539,15 +47539,15 @@
 			}
 		},
 		"core-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-			"integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
+			"integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-			"integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+			"integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
 			"requires": {
 				"browserslist": "^4.16.7",
 				"semver": "7.0.0"
@@ -47561,9 +47561,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.1.tgz",
-			"integrity": "sha512-TyofCdMzx0KMhi84mVRS8rL1XsRk2SPUNz2azmth53iRN0/08Uim9fdhQTaZTG1LqaXHYVci4RDHka6WrXfnvg==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+			"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -48719,9 +48719,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.806",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-			"integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+			"version": "1.3.808",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.808.tgz",
+			"integrity": "sha512-espnsbWTuUw0a2jMwfabCc09py2ujB+FZZE1hZWn5yYijEmxzEhdhTLKUfZGjynHvdIMQ4X/Pr/t8s4eiyH/QQ=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.3",
@@ -59650,9 +59650,9 @@
 			}
 		},
 		"react-devtools-core": {
-			"version": "4.15.0",
-			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.15.0.tgz",
-			"integrity": "sha512-Y1NwrWSKRg4TtwcES2upzXFDmccAW9jrGQG2D8EGQrZhK+0hmuhgFnSdKpFc3z04CSeDT5t83RMXcmX5TkR1dA==",
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.16.0.tgz",
+			"integrity": "sha512-fqyVbp+wVVey6O4uVBk5s3J/vTiPludp7lulr6a8asTBm7DIA0vLBbjmAOLCnOlkWcgdy4mjsqOgNCbu8uICWw==",
 			"peer": true,
 			"requires": {
 				"shell-quote": "^1.6.1",
@@ -61542,9 +61542,9 @@
 			}
 		},
 		"sass": {
-			"version": "1.37.5",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-			"integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+			"integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
 			"dev": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0"


### PR DESCRIPTION
This PR proposes an updated and regenerated `package-lock.json` file using NPM 7, with the aim of addressing the [blocked](https://github.com/sixach/wp-block-components/pulls) PRs from rennovate regarding the ⚠ Artifact update problem.

The lock file has been regenerated based on the `main` branch, which lock file has been recently regenerated (and merged) via [this](https://github.com/sixach/wp-block-components/pull/53/files) rennovate PR.