### PR TITLE
Open Source Preparation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@sixach/wp-block-components",
+	"name": "@sixa/wp-block-components",
 	"version": "1.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@sixach/wp-block-components",
+			"name": "@sixa/wp-block-components",
 			"version": "1.6.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@sixach/wp-block-components",
+	"name": "@sixa/wp-block-components",
 	"version": "1.6.0",
 	"description": "A collection of most used React components crafted for the sixa projects.",
 	"keywords": [
@@ -97,6 +97,6 @@
 		"wp-prettier": "^2.2.1-beta-1"
 	},
 	"publishConfig": {
-		"registry": "https://npm.pkg.github.com/"
+		"access": "public"
 	}
 }


### PR DESCRIPTION
This PR changes the `publishConfig` for a release on our public NPM registry. Also, I have changed the package scope from `@sixach` to `@sixa`.

**IMPORTANT NOTICE**: After merging this PR and before publishing the repository, I will remove the package that's currently being hosted on NPM. As a consequence, every project that uses `@sixach/wp-block-components` will break during NPM installation.