### PR TITLE
Installed opinionated prettier package for WordPress 🐛 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
 				"cross-env": "7.0.3",
 				"husky": "^7.0.2",
 				"lint-staged": "^11.2.0",
-				"wp-prettier": "^2.2.1-beta-1"
+				"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 			}
 		},
 		"node_modules/@babel/cli": {
@@ -10195,19 +10195,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/@wordpress/hooks": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.1.tgz",
@@ -11652,19 +11639,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/read-pkg": {
@@ -26565,11 +26539,11 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+			"name": "wp-prettier",
+			"version": "2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -34030,18 +34004,6 @@
 			"dev": true,
 			"dependencies": {
 				"microevent.ts": "~0.1.1"
-			}
-		},
-		"node_modules/wp-prettier": {
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/wrap-ansi": {
@@ -41723,12 +41685,6 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-					"dev": true
 				}
 			}
 		},
@@ -42771,12 +42727,6 @@
 						"postcss-selector-parser": "^6.0.5",
 						"uniqs": "^2.0.0"
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
@@ -54327,11 +54277,10 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
-			"dev": true,
-			"peer": true
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -60160,12 +60109,6 @@
 			"requires": {
 				"microevent.ts": "~0.1.1"
 			}
-		},
-		"wp-prettier": {
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"cross-env": "7.0.3",
 		"husky": "^7.0.2",
 		"lint-staged": "^11.2.0",
-		"wp-prettier": "^2.2.1-beta-1"
+		"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This PR proposes to replace the already installed `wp-prettier` package with the opinionated [prettier](https://github.com/Automattic/wp-prettier) module for WordPress instead.