### PR TITLE
Bumped Version :)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-block-components",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-block-components",
-			"version": "1.8.1",
+			"version": "1.8.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@emotion/styled": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-block-components",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "A collection of most used React components crafted for the sixa projects.",
 	"keywords": [
 		"sixa",


### PR DESCRIPTION
I updated the colors in the [VisibilityToolbar PR](https://github.com/sixach/wp-block-components/pull/84) but only noticed after publishing that I mixed up the active state colors with the default state colors. Unpublishing a package on NPM does not enable one to republish a different bundle with the same version number. Thus, we need to bump the version again. 

I have already published this version though (so this is mostly an FYI PR).