### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,10 @@
 # Define @wp-devs, as the code owners of the repo so the team is
 # tagged to review new PRs automatically.
 *       @sixach/wp-devs
+
+# Unassign renovate generated pull requests from "wp-devs" group. (Unowned)
+/.github
+composer.json
+composer.lock
+package.json
+package-lock.json


### PR DESCRIPTION
This PR unassigns renovate generated pull requests from "wp-devs" group.